### PR TITLE
[SUBSCRIBER-SIGNUP] Add resend email verification support

### DIFF
--- a/src/RESTAPI/RESTAPI_signup_handler.cpp
+++ b/src/RESTAPI/RESTAPI_signup_handler.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-02-20.
 //

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-02-21.
 //


### PR DESCRIPTION
Fix Type: Feature
Root Cause:
 - Signup API lacked support for resending email verification for pending subscribers. Solution:
 - Add resend parameter to allow refreshing verification for users waiting on email confirmation.
 - Improve signup logging and clarify signup error message.