### PR TITLE
feat(security): align user email verification with password setup flow

### DIFF
--- a/src/RESTAPI/RESTAPI_action_links.cpp
+++ b/src/RESTAPI/RESTAPI_action_links.cpp
@@ -119,6 +119,12 @@ namespace OpenWifi {
 				return DoReturnA404();
 			}
 
+			if (Link.action != SecurityObjects::LinkActions::FORGOT_PASSWORD &&
+				Link.action != SecurityObjects::LinkActions::SUB_FORGOT_PASSWORD &&
+				!(Link.userAction && Link.action == SecurityObjects::LinkActions::VERIFY_EMAIL)) {
+				return DoReturnA404();
+			}
+
 			if (Password1 != Password2 || !AuthService()->ValidatePassword(Password2) ||
 				!AuthService()->ValidatePassword(Password1)) {
 				Poco::File FormFile{Daemon()->AssetDir() + "/password_reset_error.html"};
@@ -176,6 +182,7 @@ namespace OpenWifi {
 				UInfo.validated = true;
 				UInfo.lastEmailCheck = OpenWifi::Now();
 				UInfo.validationDate = OpenWifi::Now();
+				UInfo.changePassword = false;
 			}
 
 			UInfo.modified = OpenWifi::Now();

--- a/src/RESTAPI/RESTAPI_action_links.cpp
+++ b/src/RESTAPI/RESTAPI_action_links.cpp
@@ -171,6 +171,13 @@ namespace OpenWifi {
 				return SendHTMLFileBack(FormFile, FormVars);
 			}
 
+			if (Link.action == OpenWifi::SecurityObjects::LinkActions::VERIFY_EMAIL) {
+				UInfo.waitingForEmailCheck = false;
+				UInfo.validated = true;
+				UInfo.lastEmailCheck = OpenWifi::Now();
+				UInfo.validationDate = OpenWifi::Now();
+			}
+
 			UInfo.modified = OpenWifi::Now();
 			if (Link.userAction)
 				StorageService()->UserDB().UpdateUserInfo(UInfo.email, Link.userId, UInfo);
@@ -316,6 +323,10 @@ namespace OpenWifi {
 			return SendHTMLFileBack(FormFile, FormVars);
 		}
 
+		if (Link.userAction) {
+			return RequestResetPassword(Link);
+		}
+
 		Logger_.information(fmt::format("EMAIL-VERIFICATION(%s): For ID={}",
 										Request->clientAddress().toString(), UInfo.email));
 		UInfo.waitingForEmailCheck = false;
@@ -323,10 +334,7 @@ namespace OpenWifi {
 		UInfo.lastEmailCheck = OpenWifi::Now();
 		UInfo.validationDate = OpenWifi::Now();
 		UInfo.modified = OpenWifi::Now();
-		if (Link.userAction)
-			StorageService()->UserDB().UpdateUserInfo(UInfo.email, Link.userId, UInfo);
-		else
-			StorageService()->SubDB().UpdateUserInfo(UInfo.email, Link.userId, UInfo);
+		StorageService()->SubDB().UpdateUserInfo(UInfo.email, Link.userId, UInfo);
 		Types::StringPairVec FormVars{{"UUID", Link.id},
 									  {"USERNAME", UInfo.email},
 									  {"ACTION_LINK", MicroService::instance().GetUIURI()}};

--- a/src/RESTAPI/RESTAPI_action_links.cpp
+++ b/src/RESTAPI/RESTAPI_action_links.cpp
@@ -119,9 +119,16 @@ namespace OpenWifi {
 				return DoReturnA404();
 			}
 
-			if (Link.action != SecurityObjects::LinkActions::FORGOT_PASSWORD &&
-				Link.action != SecurityObjects::LinkActions::SUB_FORGOT_PASSWORD &&
-				!(Link.userAction && Link.action == SecurityObjects::LinkActions::VERIFY_EMAIL)) {
+			const bool ValidUserAction =
+				Link.userAction &&
+				(Link.action == SecurityObjects::LinkActions::FORGOT_PASSWORD ||
+				 Link.action == SecurityObjects::LinkActions::VERIFY_EMAIL);
+
+			const bool ValidSubscriberAction =
+				!Link.userAction &&
+				Link.action == SecurityObjects::LinkActions::SUB_FORGOT_PASSWORD;
+
+			if (!ValidUserAction && !ValidSubscriberAction) {
 				return DoReturnA404();
 			}
 


### PR DESCRIPTION
## Overview
This PR aligns the standard user email verification onboarding flow with the subscriber password setup flow. When a new standard user is created with a temporary password and email verification enabled:
1. Clicking the email link redirects them to set a permanent password (reusing the existing `password_reset.html` form).
2. Submitting the new password marks the user as validated (`validated = true`, `waitingForEmailCheck = false`) and clears the change password flag (`changePassword = false`), enabling direct login to the frontend UI.

## Changes
1. **`src/RESTAPI/RESTAPI_action_links.cpp`**:
   * Intercepted `DoEmailVerification` for standard users (`Link.userAction == true`) to redirect them to `RequestResetPassword(Link)` rather than immediately verifying the email.
   * In `CompleteResetPassword`, set the user email validation flags and explicitly set `changePassword = false` if the source link action was `LinkActions::VERIFY_EMAIL`.
   * Added an explicit `Link.action` allowlist check inside `CompleteResetPassword()` to restrict the password update handler to only valid reset and verification actions.
   * Cleaned up the redundant `if (Link.userAction)` conditional update branch at the end of `DoEmailVerification`, as standard users are redirected early and it now only processes subscriber DB updates.

## Impact & Verification
* **Impact:** Standard users can now verify their email and set their permanent password in a single, unified flow, allowing them to log in directly to the frontend UI without being forced into an extra password change redirection.
* **Testing:** Verified that visiting the email verification page correctly routes standard users to the password form, and submitting the new password flags the user as verified with `changePassword = false` in the database.
