### PR TITLE
fix(framework): load full CA certificate chain instead of first block

### DIFF
--- a/src/framework/SubSystemServer.cpp
+++ b/src/framework/SubSystemServer.cpp
@@ -50,11 +50,21 @@ namespace OpenWifi {
 
 		if (!cert_file_.empty() && !key_file_.empty()) {
 			Poco::Crypto::X509Certificate Cert(cert_file_);
-			Poco::Crypto::X509Certificate Root(root_ca_);
-
 			Context->useCertificate(Cert);
-			Context->addChainCertificate(Root);
-			Context->addCertificateAuthority(Root);
+
+			if (!root_ca_.empty()) {
+				try {
+					std::vector<Poco::Crypto::X509Certificate> RootCerts =
+						Poco::Net::X509Certificate::readPEM(root_ca_);
+					for (const auto &rc : RootCerts) {
+						Context->addChainCertificate(rc);
+						Context->addCertificateAuthority(rc);
+					}
+				} catch (const Poco::Exception &E) {
+					L.fatal(fmt::format("Failed to load CA certificate chain from {}: {}", root_ca_, E.displayText()));
+					throw;
+				}
+			}
 
 			if (level_ == Poco::Net::Context::VERIFY_STRICT) {
 				if (issuer_cert_file_.empty()) {


### PR DESCRIPTION
fix #20 

## Summary

This PR fixes a bug in the SSL context initialization where only the first certificate block from the CA file, `root_ca_`, was being loaded and presented during the TLS handshake.

## The Problem

In `SubSystemServer::CreateSecureSocket`, CA certificates were previously loaded using:

```cpp
Poco::Crypto::X509Certificate Root(root_ca_);
```

By design, this constructor only parses the first PEM block in the file and ignores any subsequent certificate blocks.

This became an issue after Let's Encrypt's transition to the new Generation Y hierarchy, which requires presenting a 3-certificate chain, including a cross-signed Root YR bridge certificate, to remain compatible with older devices and trust stores.

Without the bridge certificate, strict TLS clients such as mobile applications or Postman with SSL verification enabled rejected connections with the following error:

```text
unable to get local issuer certificate
```

## The Solution

`CreateSecureSocket` has been updated to load all CA certificates from the PEM file by using:

```cpp
Poco::Net::X509Certificate::readPEM(root_ca_)
```

The resulting certificate vector is then iterated so that each intermediate or bridge certificate is added to the SSL context.

A safe `try-catch` block has also been added to logs the parse failure details via `L.fatal`, and rethrows the exception to fail fast immediately.

## Testing

Verified the certificate chain using:

```bash
openssl s_client -connect <host>:<port_16001> -showcerts
```

Confirmed that all 3 certificates are now successfully presented during the TLS handshake:

* Leaf certificate
* YR1 intermediate certificate
* Root YR bridge certificate

Also verified that strict TLS clients can now successfully establish secure connections to the server, including:

* Mobile clients
* Postman with **SSL Certificate Verification** turned ON
