### PR TITLE
added functionality for owner and user getting self data

### DIFF
--- a/src/RESTAPI/RESTAPI_user_handler.cpp
+++ b/src/RESTAPI/RESTAPI_user_handler.cpp
@@ -107,7 +107,8 @@ namespace OpenWifi {
 		void ApplyOwnerUpdate(const SecurityObjects::UserInfoAndPolicy &Caller,
 							  const Poco::JSON::Object::Ptr &RawObject,
 							  SecurityObjects::UserInfo &Existing) {
-			if (RawObject->has("owner") && Caller.userinfo.userRole == SecurityObjects::ROOT &&
+			if (RawObject->has("owner") &&
+				(Caller.userinfo.userRole == SecurityObjects::ROOT || Caller.userinfo.userRole == SecurityObjects::ADMIN) &&
 				Existing.owner.empty()) {
 				RESTAPIHandler::AssignIfPresent(RawObject, "owner", Existing.owner);
 			}
@@ -332,7 +333,7 @@ namespace OpenWifi {
 		}
 
 		NewUser.createdBy = UserInfo_.userinfo.id;
-		if (UserInfo_.userinfo.userRole == SecurityObjects::ROOT) {
+		if (UserInfo_.userinfo.userRole == SecurityObjects::ROOT || UserInfo_.userinfo.userRole == SecurityObjects::ADMIN) {
 			NewUser.owner = GetParameter("entity", "");
 		} else {
 			NewUser.owner = UserInfo_.userinfo.owner;

--- a/src/RESTAPI/RESTAPI_users_handler.cpp
+++ b/src/RESTAPI/RESTAPI_users_handler.cpp
@@ -9,21 +9,11 @@
 
 namespace OpenWifi {
 
-	namespace {
-		inline bool IsAdminUserCaller(const SecurityObjects::UserInfo &User) {
-			return User.userRole == SecurityObjects::ROOT || User.userRole == SecurityObjects::ADMIN;
-		}
-	}
-
 	void RESTAPI_users_handler::DoGet() {
 
 		bool IdOnly = (GetParameter("idOnly", "false") == "true");
 		auto nameSearch = GetParameter("nameSearch");
 		auto emailSearch = GetParameter("emailSearch");
-
-		if (!IsAdminUserCaller(UserInfo_.userinfo)) {
-			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
-		}
 
 		std::string baseQuery;
 		if (!nameSearch.empty() || !emailSearch.empty()) {
@@ -38,9 +28,16 @@ namespace OpenWifi {
 											   ORM::Escape(Poco::toLower(emailSearch)));
 		}
 
-		if (UserInfo_.userinfo.userRole == SecurityObjects::ADMIN) {
-			auto AdminScope = fmt::format(" createdby='{}' ", ORM::Escape(UserInfo_.userinfo.id));
+		if (UserInfo_.userinfo.userRole == SecurityObjects::ROOT) {
+			// root can list all users
+		} else if (UserInfo_.userinfo.userRole == SecurityObjects::ADMIN) {
+			auto AdminScope = fmt::format(" (createdby='{}' or id='{}') ",
+										  ORM::Escape(UserInfo_.userinfo.id),
+										  ORM::Escape(UserInfo_.userinfo.id));
 			baseQuery = baseQuery.empty() ? AdminScope : fmt::format("{} and {}", AdminScope, baseQuery);
+		} else {
+			auto SelfScope = fmt::format(" id='{}' ", ORM::Escape(UserInfo_.userinfo.id));
+			baseQuery = baseQuery.empty() ? SelfScope : fmt::format("{} and {}", SelfScope, baseQuery);
 		}
 
 		if (QB_.Select.empty()) {


### PR DESCRIPTION
# Summary

This PR adds support for users to retrieve their own user data through the Users API and improves admin-scoped user listing behavior.

# Changes

- Updated `GET /api/v1/users` behavior:
  - `ROOT` users can list all users.
  - `ADMIN` users can list users created by them and their own user record.
  - Non-admin users can retrieve only their own user record.
- Updated the user creation flow so `ADMIN` users are handled similarly to `ROOT` for owner assignment during user creation.
- Updated owner update logic to allow `ADMIN` users to assign owner information when the target user's owner is empty.
- Updated OAuth handler configuration.

# Purpose

This change supports self-service user profile access, allowing normal users and owners to retrieve their own account details without requiring root/admin-level listing permissions.

# Validation Required

Please verify the following before merging:

- Normal users can fetch only their own user data.
- Normal users cannot access other users through `GET /api/v1/users`.
- Admin users can see their own user record.
- Admin users can see users created by them.
- Root users can still list all users.
- Owner assignment behavior is correct for admin-created users.
- OAuth endpoint rate-limiting behavior remains correct.

# Notes

This PR changes authorization-sensitive behavior. Please carefully review the user visibility rules and owner-scoping logic before merging.